### PR TITLE
pulls next weeks worth of events from api  and stores refresh token i…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^8.2.0",
         "eslint": "^7.32.0",
+        "google-auth-library": "^3.1.2",
         "googleapis": "^39.2.0",
         "passport": "^0.4.1",
         "passport-google-oauth20": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "eslint": "^7.32.0",
+    "google-auth-library": "^3.1.2",
     "googleapis": "^39.2.0",
     "passport": "^0.4.1",
     "passport-google-oauth20": "^2.0.0",

--- a/server/controllers/eventController.js
+++ b/server/controllers/eventController.js
@@ -1,86 +1,137 @@
 const { query } = require('../../db/db.js');
 const pool = require('../../db/db.js');
+const {google} = require('googleapis');
+var googleAuth = require('google-auth-library');
 
 // Declare empty event controller obj
 const eventController = {};
 
 //store user in db with token
-eventController.addUser = (profile, accessToken) => {
+eventController.addUser = (profile, accessToken, refreshToken) => {
+  //store user in DB, upsert so if user already exists just updates token if it's changed
   pool.query(`INSERT INTO users(
     id,
     first_name,
     last_name,
-    token)VALUES(
+    token,
+    refreshtoken)VALUES(
       '${profile.id}',
       '${profile.name.givenName}',
       '${profile.name.familyName}',
-      '${accessToken}'
-  )`)
-}
-
-// TODO: Currently commented out for the next step in the project (bringing in the google API data)
-// Get the calendar events from the Google calendar api
-eventController.getCalEvents = (req, res, next) => {
-  const getEvents = [{date: '26/09/21', name: 'Michael\'s Birthday'},{date: '27/09/21', name: 'Day After Michael\'s Birthday'}]
-  res.locals.events = getEvents;
-  next();
+      '${accessToken}',
+      '${refreshToken}'
+  ) ON CONFLICT (id) DO UPDATE
+  SET token = '${accessToken}'`)
+  .catch(err => {
+    console.log('err in addUser', err)
+  })
 }
 
 // Push the calendar events to the event database
-eventController.pushCalEvents = (req, res, next) => {
-  pool.query(
-    `INSERT INTO raw_cal_events(
-    id,
-    insertion_timestamp,
-    cal_owner_user_id,
-    event_kind,
-    event_tag,
-    event_id,
-    status,
-    event_html_link,
-    event_created_ts,
-    event_updated_ts,
-    event_summary,
-    event_creator_email,
-    event_organizer_email,
-    event_start_ts,
-    event_start_timezone,
-    event_end_ts,
-    event_end_timezone,
-    recurring_event_id,
-    event_original_start_ts,
-    event_original_start_timezone,
-    event_uid,
-    event_sequence,
-    event_type)VALUES(
-      // TODO: Placeholder values until we are able to successfully pull directly from the Google API
-      '1002030235',
-      NOW(),
-      'test1',
-      'test2',
-      'test3',
-      'test4',
-      'test5',
-      'test6',
-      '2003-2-1'::timestamp,
-      '2003-2-1'::timestamp,
-      'test7',
-      'test8',
-      'test9',
-      '2003-2-1'::timestamp,
-      'test10',
-      '2003-2-1'::timestamp,
-      'test',
-      'test',
-      '2003-2-1'::timestamp,
-      'test',
-      'test',
-      'test',
-      'test')
-    `
-    , (err, res) => {
-        console.log(err, res);
-      })
-    }
+eventController.pushCalEvents = async(accessToken, profile) => {
+  //pull data from api for arr of event objects
+  // const auth = new googleAuth();
+  let oAuth2Client = new google.auth.OAuth2(
+    process.env.CLIENT_ID,
+    process.env.CLIENT_SECRET,
+    'http://localhost:5000/auth/google/callback'
+);
 
+//get both tokens including refresh
+const url = oAuth2Client.generateAuthUrl({
+  access_type: 'offline', // will return a refresh token
+  scope: ['profile', 'https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/calendar.events']
+});
+
+
+console.log(oAuth2Client);
+console.log('profile id', profile.id)
+//query db for user to get refresh token even if not first login
+const userObj = await pool.query(
+  `SELECT * FROM "users" WHERE id = '${profile.id}'`
+)
+console.log('UserObj is here', userObj);
+
+// Now use OAuth response to get an user authenticated API client
+let credentials = {
+    access_token: accessToken,
+    token_type:'Bearer', // mostly Bearer
+    refresh_token:userObj.rows[0].refreshtoken,
+    // expiry_date:'EXPIRY_TIME'
+};
+oAuth2Client.setCredentials(credentials);
+
+  const calendar = google.calendar({version: 'v3', auth: oAuth2Client});
+  
+  //grab next weeks worth of events
+  const eventsArray =  calendar.events.list({
+    calendarId: 'bgro63@gmail.com',
+    timeMin: (new Date()).toISOString(),
+    timeMax: (new Date(new Date().getTime() + 7 * 24 * 60 * 60 * 1000)).toISOString(),
+    maxResults: 500,
+    singleEvents: true,
+    orderBy: 'startTime',
+  }, (err, res) => {
+    if (err) return console.log('The API returned an error: ' + err);
+    const events = res.data.items;
+    console.log('events', events);
+  });
+   console.log('these are the events',eventsArray);
+// })
+// }
+  // pool.query(
+  //   `INSERT INTO raw_cal_events(
+  //   id,
+  //   insertion_timestamp,
+  //   cal_owner_user_id,
+  //   event_kind,
+  //   event_tag,
+  //   event_id,
+  //   status,
+  //   event_html_link,
+  //   event_created_ts,
+  //   event_updated_ts,
+  //   event_summary,
+  //   event_creator_email,
+  //   event_organizer_email,
+  //   event_start_ts,
+  //   event_start_timezone,
+  //   event_end_ts,
+  //   event_end_timezone,
+  //   recurring_event_id,
+  //   event_original_start_ts,
+  //   event_original_start_timezone,
+  //   event_uid,
+  //   event_sequence,
+  //   event_type)VALUES(
+  //     // TODO: Placeholder values until we are able to successfully pull directly from the Google API
+  //     '1002030235',
+  //     NOW(),
+  //     'test1',
+  //     'test2',
+  //     'test3',
+  //     'test4',
+  //     'test5',
+  //     'test6',
+  //     '2003-2-1'::timestamp,
+  //     '2003-2-1'::timestamp,
+  //     'test7',
+  //     'test8',
+  //     'test9',
+  //     '2003-2-1'::timestamp,
+  //     'test10',
+  //     '2003-2-1'::timestamp,
+  //     'test',
+  //     'test',
+  //     '2003-2-1'::timestamp,
+  //     'test',
+  //     'test',
+  //     'test',
+  //     'test')
+  //   `
+  //   , (err, res) => {
+  //       console.log(err, res);
+  //     })
+  //   }
+}
 module.exports = eventController

--- a/server/router/api.js
+++ b/server/router/api.js
@@ -2,16 +2,16 @@ const router = require('express').Router();
 const eventController = require('../controllers/eventController.js');
 
 // Get calendar events - send status 200 with events if success - catch err if not
-router.get('/getevents',
-eventController.getCalEvents,(req, res) => {
-  try {
-    res.status(200).json(res.locals.events);
-  }
-  catch(err) {
-    console.log('There\'s an issue in the router: ',err)
-  }
-}
-);
+// router.get('/getEvents',
+// eventController.getEvents,(req, res) => {
+//   try {
+//     res.status(200).json(res.locals.events);
+//   }
+//   catch(err) {
+//     console.log('There\'s an issue in the router: ',err)
+//   }
+// }
+// );
 
 module.exports = router;
 

--- a/server/server.js
+++ b/server/server.js
@@ -37,14 +37,17 @@ async function(accessToken, refreshToken, profile, done) {
   // User.findOrCreate({ googleId: profile.id }, function (err, user) {
   //   return cb(err, user);
   // });
+  console.log('access toke', accessToken);
+  console.log('refresh token', refreshToken)
+  console.log('profile', profile);
+  
   //add user to db with their access token for future api calls
   try {
-  await eventController.addUser(profile, accessToken);
+  await eventController.addUser(profile, accessToken, refreshToken);
+  await eventController.pushCalEvents(accessToken, profile);
   } catch (err) {
     console.log(err);
   }
-  console.log('access toke', accessToken);
-  console.log('profile', profile);
   
   return done(null, {
     profile: profile,
@@ -67,7 +70,9 @@ console.log('made it just before redirect');
 
 //passport routes
 app.get('/auth/google',
-  passport.authenticate('google', { scope: ['profile', 'https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/calendar.events'] }));
+  passport.authenticate('google', { scope: ['profile', 'https://www.googleapis.com/auth/calendar', 'https://www.googleapis.com/auth/calendar.events'], accessType: 'offline',
+  prompt: 'consent'
+ }));
 // ^^ provides read write access to user calendars and events within calendar, see https://developers.google.com/calendar/api/guides/auth
 app.get('/auth/google/callback',
   passport.authenticate('google', { failureRedirect: '/loginfailure', successRedirect: '/' }),


### PR DESCRIPTION
### Summary

*What's the summary of your pull request? What problem are you solving or feature you are implementing? (e.g. Altered the backend to add POST functionality)*

- added refresh token to users table
- pull next week's worth of events from gcal api, though calendar id is still hardcoded email and must be updated

### Changes being made

- get and store refresh token in pushevents controller func
- pull cal events from gcal ap

### Validation tests

- we successfully see a console log of arr of obj of gcal events

### Implementation reasoning

*Why did you implement it in this way?*

- need the refresh token to access gcal api, only given on first auth
- need events for our functionality